### PR TITLE
Replace "Enable on browser startup" with remembering the last enabled status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 Fork of https://github.com/AsciiJakob/NoDistractions
 
-Done some code cleanup so that it's easier to make changes, and planning to hack on a couple ideas.
+I had some issues with code formatting so I started this fork to clean that up and then add some features I need.
 
 ## Added features
 
-todo
+* Remember enabled status from when browser was last closed
+
+## Removed features
+
+* Removed the setting "Enable on browser startup", because remembering the last enabled status is more useful and intuitive to me
 
 ## Planned features
 
-* Remember enabled status from when browser was last closed
 * Show a small popup/indication when toggling with key shortcut
 
 ## Build instruction

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodistractions-fork",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "NoDistractions fork",
   "type": "module",
   "dependencies": {

--- a/src/background/Background.js
+++ b/src/background/Background.js
@@ -8,9 +8,9 @@ export let enabled = {
     setStatus(newStatus) {
         this.status = newStatus;
         updateIconState(this.status);
+        browser.storage.local.set({lastEnabledStatus: this.status})
     }
 };
-
 
 browser.runtime.onMessage.addListener(handleMessage);
 browser.runtime.onInstalled.addListener(async details => {
@@ -25,13 +25,20 @@ browser.runtime.onInstalled.addListener(async details => {
     await checkMissingSettings(await getActiveSettings());
     initalize();
 });
+
 async function initalize() {
     console.log("initializing background listeners");
     await BlockHandler.updateRequestListener();
-    browser.storage.local.get("settings").then(res => {
-        enabled.setStatus(res.settings.enableOnStartup);
+
+    browser.storage.local.get("lastEnabledStatus").then(res => {
+        const status = res.lastEnabledStatus;
+        if (status !== undefined) {
+            enabled.setStatus(status);
+        } else {
+            enabled.setStatus(false);
+        }
     });
-} 
+}
 initalize();
 
 async function handleMessage(request, sender, sendResponse) {

--- a/src/settings/Settings.html
+++ b/src/settings/Settings.html
@@ -8,8 +8,6 @@
     <body>
         <h1 id="settingstext">Settings</h1>
         <div id="settingsContainer">
-            <label>Enable on browser startup <input class="setting" type="checkbox" id="enableOnStartup"/></label>
-            <br>
             <label>Show the option to disable NoDistractions on the blocked page<input class="setting" type="checkbox" id="showDisableButton"/></label>
             <br>
             <label>Show the option to temporarily visit a blocked site on the blocked page<input class="setting" type="checkbox" id="showVisitAnyways"/></label>

--- a/src/shared/SettingsUtilities.js
+++ b/src/shared/SettingsUtilities.js
@@ -1,5 +1,4 @@
 const defaultSettings = {
-    enableOnStartup: false,
     showDisableButton: true,
     showVisitAnyways: true,
     visitAnywaysLength: 3


### PR DESCRIPTION
NoDistractions enabled status persists between browser sessions, which is what I was using the "Enable on browser startup" setting manually but it was tedious, so in my opinion this is a replacement.